### PR TITLE
Open Class

### DIFF
--- a/Sources/OutlineViewDiffableDataSource.swift
+++ b/Sources/OutlineViewDiffableDataSource.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 /// Offers a diffable interface for providing content for `NSOutlineView`.  It automatically performs insertions, deletions, and moves necessary to transition from one model-state snapshot to another.
-public class OutlineViewDiffableDataSource: NSObject, NSOutlineViewDataSource, NSOutlineViewDelegate {
+open class OutlineViewDiffableDataSource: NSObject, NSOutlineViewDataSource, NSOutlineViewDelegate {
 
   /// Shortcut for outline view objects.
   public typealias Item = DiffableDataSourceSnapshot.Item


### PR DESCRIPTION
Make class open to allow for subclassing to implement required delegate methods.

In my own use case, I could implement something like:

```swift
class SidebarDatasource: OutlineViewDiffableDataSource {
    
    let selectionWillChangeHandler: ((_ notification: Notification) -> Void)?
    let selectionDidChangeHandler: ((_ notification: Notification) -> Void)?
    
    init(outlineView: NSOutlineView, selectionWillChangeHandler:((_ notification: Notification) -> Void)?, selectionDidChangeHandler:((_ notification: Notification) -> Void)?) {
        
        self.selectionWillChangeHandler = selectionWillChangeHandler
        self.selectionDidChangeHandler = selectionDidChangeHandler
        
        super.init(outlineView: outlineView)
        
    }
    
    func outlineViewSelectionIsChanging(_ notification: Notification) {
        selectionWillChangeHandler?(notification)
    }
    
    func outlineViewSelectionDidChange(_ notification: Notification) {
        selectionDidChangeHandler?(notification)
    }
    
}
```